### PR TITLE
Add workflow to generate pizza seed data daily

### DIFF
--- a/.github/workflows/generate_pizza_data.yml
+++ b/.github/workflows/generate_pizza_data.yml
@@ -1,0 +1,24 @@
+name: Generate Pizza Data
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.12-slim
+    steps:
+      - uses: "actions/checkout@v4"
+      - name: Install uv
+        run: python -m pip install uv
+      - name: Install dependencies
+        run: uv pip install -r requirements.txt --system
+      - name: Generate pizza data
+        run: |
+          cd scripts
+          python create_pizza_data.py
+          mv raw_pizza_sales.csv ../seeds/raw_pizza_sales.csv
+          mv ingredients.csv ../seeds/ingredients.csv


### PR DESCRIPTION
## Summary
- add GitHub Action to run `create_pizza_data.py` once a day
- switch runner to a small Ubuntu-based container

## Testing
- `pre-commit` *(fails: command not found)*